### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/behnam0579/760b13d1-cd3e-4f8a-8d6c-240e28c22eda/4d884fd9-4bca-43a8-8951-84783c72dc13/_apis/work/boardbadge/bc31cbf2-b774-4b4c-a3b8-9b74facd7bf1)](https://dev.azure.com/behnam0579/760b13d1-cd3e-4f8a-8d6c-240e28c22eda/_boards/board/t/4d884fd9-4bca-43a8-8951-84783c72dc13/Microsoft.RequirementCategory)
 ---
 services: app-service\web,app-service
 platforms: dotnet


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/behnam0579/760b13d1-cd3e-4f8a-8d6c-240e28c22eda/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.